### PR TITLE
fix: custom push get error without encoding url params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+Cargo.lock

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,6 +320,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "tokio",
+ "urlencoding",
 ]
 
 [[package]]
@@ -1662,6 +1663,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ ctrlc = "3.2.3"
 rand = "0.8.5"
 actix-governor = "0.3.1"
 governor = "0.4.2"
+urlencoding = "2.1.2"
 
 [profile.fast]
 inherits = "release"

--- a/config.example.json
+++ b/config.example.json
@@ -142,9 +142,25 @@
   },
   "report_open": false,
   "report_config": {
-    "method": "Post",
-    "url": "https://api.telegram.org/bot{your_token}/sendMessage",
-    "content": "chat_id={your_chat_id}&text=大陆 Playurl:              {CnPlayurl}\n香港 Playurl:              {HkPlayurl}\n台湾 Playurl:              {TwPlayurl}\n泰区 Playurl:              {ThPlayurl}\n大陆 Search:              {CnSearch}\n香港 Search:              {HkSearch}\n台湾 Search:              {TwSearch}\n泰区 Search:              {ThSearch}\n泰区 Season:              {ThSeason}\n\n变动: {ChangedAreaName} {ChangedDataType} -> {ChangedHealthType}"
+    "use_method": "tg_bot",
+    "tg_bot_config": {
+      "tg_bot_token": "",
+      "tg_chat_id": "",
+      "tg_proxy_api_open": false,
+      "tg_proxy_url": ""
+    },
+    "pushplus_config": {
+      "pushplus_push_title": "",
+      "pushplus_secret": "",
+      "pushplus_group_id": ""
+    },
+    "custom_config": {
+      "method": "Post",
+      "url": "https://api.telegram.org/bot{your_token}/sendMessage",
+      "content": "chat_id={your_chat_id}&text=大陆 Playurl:              {CnPlayurl}\n香港 Playurl:              {HkPlayurl}\n台湾 Playurl:              {TwPlayurl}\n泰区 Playurl:              {ThPlayurl}\n大陆 Search:              {CnSearch}\n香港 Search:              {HkSearch}\n台湾 Search:              {TwSearch}\n泰区 Search:              {ThSearch}\n泰区 Season:              {ThSeason}\n\n变动: {ChangedAreaName} {ChangedDataType} -> {ChangedHealthType}",
+      "proxy_open": false,
+      "proxy_url": ""
+    }
   },
   "area_cache_open": false
 }

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,8 +1,12 @@
+config_version: 2
 auto_update: false
 auto_close: true
 redis: redis://:password@host:6379
 woker_num: 8
 port: 2662
+limit_biliroaming_version_open: false,
+limit_biliroaming_version_min: 64,
+limit_biliroaming_version_max: 80,
 cn_app_playurl_api: https://api.bilibili.com/pgc/player/api/playurl
 tw_app_playurl_api: https://api.bilibili.com/pgc/player/api/playurl
 hk_app_playurl_api: https://api.bilibili.com/pgc/player/api/playurl
@@ -63,58 +67,85 @@ cn_proxy_token_url: 127.0.0.1:7890
 th_proxy_token_url: 127.0.0.1:7890
 cn_proxy_token_open: false
 th_proxy_token_open: true
+cn_proxy_accesskey_url: 127.0.0.1:7890
+cn_proxy_accesskey_open: false,
 th_proxy_subtitle_url: 127.0.0.1:7890
 th_proxy_subtitle_open: true
 aid: 127001
 aid_replace_open: true
 resign_pub:
-  '1': false
-  '3': false
-  '4': false
-  '2': false
+  "1": false
+  "3": false
+  "4": false
+  "2": false
 resign_open:
-  '2': false
-  '4': false
-  '3': false
-  '1': false
+  "2": false
+  "4": false
+  "3": false
+  "1": false
 resign_api_policy:
-  '1': false
-  '3': false
-  '2': false
-  '4': false
+  "1": false
+  "3": false
+  "2": false
+  "4": false
 resign_api:
-  '2': ''
-  '3': ''
-  '1': ''
-  '4': ''
+  "2": ""
+  "3": ""
+  "1": ""
+  "4": ""
 resign_api_sign:
-  '4': ''
-  '3': ''
-  '1': ''
-  '2': ''
+  "4": ""
+  "3": ""
+  "1": ""
+  "2": ""
 cache:
-  '-412': 1380
+  "-412": 1380
   other: 1380
-  '-404': 1380
-  '-10403': 6480
+  "-404": 1380
+  "-10403": 6480
   thsub: 14400
-  '0': 6480
+  "0": 6480
 local_wblist:
-  '114514':
-  - false
-  - false
-one_click_run: false
+  "114514":
+    - false
+    - false
+blacklist_config:
+  "MixedBlackList":
+    "api": "https://black.qimo.ink/api/users/"
+    "api_version": 2
 appsearch_remake:
   example.com: "{\"title\":\"服务器提供者：\\u003cem class\\u003d\\\"keyword\\\"\\u003eXXX\\u003c/em\\u003e\",\"cover\":\"https://示例.永雏塔菲.我爱你/src/fuck_search.jpg\",\"uri\":\"https://bili.pch.pub\",\"param\":\"1\",\"goto\":\"bangumi\",\"ptime\":1500000000,\"season_id\":1,\"season_type\":1,\"season_type_name\":\"番剧\",\"media_type\":1,\"style\":\"切勿宣扬，发现拉黑！\",\"styles\":\"切勿宣扬，发现拉黑！\",\"cv\":\"\",\"rating\":114.514,\"vote\":1919.810,\"area\":\"漫游\",\"staff\":\"无\",\"is_selection\":1,\"badge\":\"公告\",\"episodes\":[{\"position\":1,\"uri\":\"https://www.bilibili.com/video/av928861104\",\"param\":\"1\",\"index\":\"1\"}],\"label\":\"勿谓言之不预也\",\"watch_button\":{\"title\":\"\U0001F605\",\"link\":\"https://bili.pch.pub/\"},\"follow_button\":{\"icon\":\"http://i0.hdslb.com/bfs/bangumi/154b6898d2b2c20c21ccef9e41fcf809b518ebb4.png\",\"texts\":{\"0\":\"别点\",\"1\":\"你好闲啊\"},\"status_report\":\"bangumi\"},\"selection_style\":\"horizontal\",\"episodes_new\":[{\"title\":\"教程\",\"uri\":\"https://github.com/yujincheng08/BiliRoaming/wiki#使用方法\"},{\"title\":\"联系方式\",\"uri\":\"https://t.me/chenzerocheng\",\"badges\":[{\"text\":\"tg\",\"text_color\":\"#FFFFFF\",\"text_color_night\":\"#E5E5E5\",\"bg_color\":\"#58DCF9\",\"bg_color_night\":\"#58DCF9\",\"border_color\":\"#58DCF9\",\"border_color_night\":\"#58DCF9\",\"bg_style\":1}]},{\"title\":\"投喂\",\"uri\":\"https://示例.永雏塔菲.我爱你/@pinkchen\",\"badges\":[{\"text\":\"爱发电\",\"text_color\":\"#FFFFFF\",\"text_color_night\":\"#E5E5E5\",\"bg_color\":\"#B85DFF\",\"bg_color_night\":\"#A634FF\",\"border_color\":\"#B85DFF\",\"border_color_night\":\"#A634FF\",\"bg_style\":1}]},{\"title\":\"这里没东西\",\"uri\":\"https://www.bilibili.com/video/av928861104\",\"badges\":[{\"text\":\"愿者上勾\",\"text_color\":\"#FFFFFF\",\"text_color_night\":\"#E5E5E5\",\"bg_color\":\"#FB7299\",\"bg_color_night\":\"#BB5B76\",\"border_color\":\"#FB7299\",\"border_color_night\":\"#BB5B76\",\"bg_style\":1}]}],\"badges\":[{\"text\":\"萨日朗\",\"text_color\":\"#FFFFFF\",\"text_color_night\":\"#E5E5E5\",\"bg_color\":\"#00C0FF\",\"bg_color_night\":\"#0B91BE\",\"bg_style\":1}]}"
   example2.com: "{\"title\":\"服务器提供者：\\u003cem class\\u003d\\\"keyword\\\"\\u003eXXX\\u003c/em\\u003e\",\"cover\":\"https://示例.永雏塔菲.我爱你/src/fuck_search.jpg\",\"uri\":\"https://bili.pch.pub\",\"param\":\"1\",\"goto\":\"bangumi\",\"ptime\":1500000000,\"season_id\":1,\"season_type\":1,\"season_type_name\":\"番剧\",\"media_type\":1,\"style\":\"切勿宣扬，发现拉黑！\",\"styles\":\"切勿宣扬，发现拉黑！\",\"cv\":\"\",\"rating\":114.514,\"vote\":1919.810,\"area\":\"漫游\",\"staff\":\"无\",\"is_selection\":1,\"badge\":\"公告\",\"episodes\":[{\"position\":1,\"uri\":\"https://www.bilibili.com/video/av928861104\",\"param\":\"1\",\"index\":\"1\"}],\"label\":\"勿谓言之不预也\",\"watch_button\":{\"title\":\"\U0001F605\",\"link\":\"https://bili.pch.pub/\"},\"follow_button\":{\"icon\":\"http://i0.hdslb.com/bfs/bangumi/154b6898d2b2c20c21ccef9e41fcf809b518ebb4.png\",\"texts\":{\"0\":\"别点\",\"1\":\"你好闲啊\"},\"status_report\":\"bangumi\"},\"selection_style\":\"horizontal\",\"episodes_new\":[{\"title\":\"教程\",\"uri\":\"https://github.com/yujincheng08/BiliRoaming/wiki#使用方法\"},{\"title\":\"联系方式\",\"uri\":\"https://t.me/chenzerocheng\",\"badges\":[{\"text\":\"tg\",\"text_color\":\"#FFFFFF\",\"text_color_night\":\"#E5E5E5\",\"bg_color\":\"#58DCF9\",\"bg_color_night\":\"#58DCF9\",\"border_color\":\"#58DCF9\",\"border_color_night\":\"#58DCF9\",\"bg_style\":1}]},{\"title\":\"投喂\",\"uri\":\"https://示例.永雏塔菲.我爱你/@pinkchen\",\"badges\":[{\"text\":\"爱发电\",\"text_color\":\"#FFFFFF\",\"text_color_night\":\"#E5E5E5\",\"bg_color\":\"#B85DFF\",\"bg_color_night\":\"#A634FF\",\"border_color\":\"#B85DFF\",\"border_color_night\":\"#A634FF\",\"bg_style\":1}]},{\"title\":\"这里没东西\",\"uri\":\"https://www.bilibili.com/video/av928861104\",\"badges\":[{\"text\":\"愿者上勾\",\"text_color\":\"#FFFFFF\",\"text_color_night\":\"#E5E5E5\",\"bg_color\":\"#FB7299\",\"bg_color_night\":\"#BB5B76\",\"border_color\":\"#FB7299\",\"border_color_night\":\"#BB5B76\",\"bg_style\":1}]}],\"badges\":[{\"text\":\"萨日朗\",\"text_color\":\"#FFFFFF\",\"text_color_night\":\"#E5E5E5\",\"bg_color\":\"#00C0FF\",\"bg_color_night\":\"#0B91BE\",\"bg_style\":1}]}"
 websearch_remake:
-  example2.com: '{"type":"media_bangumi","media_id":1,"title":"永雏塔菲喵","org_title":"","media_type":4,"cv":"永雏塔菲\n","staff":"示例内容\n示例内容\n示例内容\n自行修改","season_id":1,"is_avid":false,"hit_columns":[],"hit_epids":"1","season_type":4,"season_type_name":"解析服务器","selection_style":"horizontal","ep_size":2,"url":"https://afdian.net/******","button_text":"捐赠","is_follow":0,"is_selection":1,"eps":[{"id":1,"cover":"https://示例.永雏塔菲.我爱你/src/fuck_search.jpg","title":"\u003cem
+  example2.com:
+    '{"type":"media_bangumi","media_id":1,"title":"永雏塔菲喵","org_title":"","media_type":4,"cv":"永雏塔菲\n","staff":"示例内容\n示例内容\n示例内容\n自行修改","season_id":1,"is_avid":false,"hit_columns":[],"hit_epids":"1","season_type":4,"season_type_name":"解析服务器","selection_style":"horizontal","ep_size":2,"url":"https://afdian.net/******","button_text":"捐赠","is_follow":0,"is_selection":1,"eps":[{"id":1,"cover":"https://示例.永雏塔菲.我爱你/src/fuck_search.jpg","title":"\u003cem
     class=\"keyword\"\u003e示例\u003c/em\u003e示例","url":"https://www.bilibili.com/video/av928861104","release_date":"","badges":null,"index_title":"1","long_title":"你好喵"}],"badges":null,"cover":"http://i0.hdslb.com/bfs/bangumi/image/4ddd37596d205978c9f97881b7a56100e85fe2e1.png","areas":"示例内容areas","styles":"示例内容styles","goto_url":"https://www.bilibili.com/video/av928861104","desc":"示例内容desc","pubtime":1609341000,"media_mode":2,"fix_pubtime_str":"","media_score":{"score":99.9,"user_count":114514},"display_info":null,"pgc_season_id":1,"corner":2,"index_show":"示例内容index_show"}'
-  example.com: '{"type":"media_bangumi","media_id":1,"title":"永雏塔菲喵","org_title":"","media_type":4,"cv":"永雏塔菲\n","staff":"示例内容\n示例内容\n示例内容\n自行修改","season_id":1,"is_avid":false,"hit_columns":[],"hit_epids":"1","season_type":4,"season_type_name":"解析服务器","selection_style":"horizontal","ep_size":2,"url":"https://afdian.net/******","button_text":"捐赠","is_follow":0,"is_selection":1,"eps":[{"id":1,"cover":"https://示例.永雏塔菲.我爱你/src/fuck_search.jpg","title":"\u003cem
+  example.com:
+    '{"type":"media_bangumi","media_id":1,"title":"永雏塔菲喵","org_title":"","media_type":4,"cv":"永雏塔菲\n","staff":"示例内容\n示例内容\n示例内容\n自行修改","season_id":1,"is_avid":false,"hit_columns":[],"hit_epids":"1","season_type":4,"season_type_name":"解析服务器","selection_style":"horizontal","ep_size":2,"url":"https://afdian.net/******","button_text":"捐赠","is_follow":0,"is_selection":1,"eps":[{"id":1,"cover":"https://示例.永雏塔菲.我爱你/src/fuck_search.jpg","title":"\u003cem
     class=\"keyword\"\u003e示例\u003c/em\u003e示例","url":"https://www.bilibili.com/video/av928861104","release_date":"","badges":null,"index_title":"1","long_title":"你好喵"}],"badges":null,"cover":"http://i0.hdslb.com/bfs/bangumi/image/4ddd37596d205978c9f97881b7a56100e85fe2e1.png","areas":"示例内容areas","styles":"示例内容styles","goto_url":"https://www.bilibili.com/video/av928861104","desc":"示例内容desc","pubtime":1609341000,"media_mode":2,"fix_pubtime_str":"","media_score":{"score":99.9,"user_count":114514},"display_info":null,"pgc_season_id":1,"corner":2,"index_show":"示例内容index_show"}'
 donate_url: https://afdian.net/@***
+api_sign: tMAi0CBC
 api_assesskey_open:
-  '3': false
-  '1': false
-  '2': false
-  '4': false
+  "3": false
+  "1": false
+  "2": false
+  "4": false
+report_config:
+  report_open: false
+  use_method: tg_bot
+  tg_bot_config:
+    tg_bot_token: ""
+    tg_chat_id: ""
+    tg_proxy_api_open": false
+    tg_proxy_url: ""
+  pushplus_config:
+    pushplus_push_title: ""
+    pushplus_secret: ""
+    pushplus_group_id: ""
+  custom_config:
+    method: "Post"
+    url: "https://api.telegram.org/bot{your_token}/sendMessage"
+    content: "chat_id={your_chat_id}&text=大陆 Playurl:              {CnPlayurl}\n香港 Playurl:              {HkPlayurl}\n台湾 Playurl:              {TwPlayurl}\n泰区 Playurl:              {ThPlayurl}\n大陆 Search:              {CnSearch}\n香港 Search:              {HkSearch}\n台湾 Search:              {TwSearch}\n泰区 Search:              {ThSearch}\n泰区 Season:              {ThSeason}\n\n变动: {ChangedAreaName} {ChangedDataType} -> {ChangedHealthType}"
+    proxy_open: false
+    proxy_url: ""
+area_cache_open: false

--- a/src/mods/push.rs
+++ b/src/mods/push.rs
@@ -1,107 +1,192 @@
+use super::request::{async_getwebpage, async_postwebpage, redis_get};
+use super::types::ReportHealthData;
+use super::types::{ReportMethod, SendHealthData};
 use deadpool_redis::Pool;
-
-use super::{
-    request::{getwebpage, postwebpage},
-    tools::health_key_to_char,
-    types::{ReportConfig, SendHealthData},
-};
+use urlencoding::encode;
 
 pub async fn send_report(
-    redis: &Pool,
-    config: &mut ReportConfig,
+    redis_pool: &Pool,
+    report_method: &ReportMethod,
     health_data: &SendHealthData,
 ) -> Result<(), ()> {
-    let health_cn_playurl = health_key_to_char(redis, "0111301").await;
-    let health_hk_playurl = health_key_to_char(redis, "0121301").await;
-    let health_tw_playurl = health_key_to_char(redis, "0131301").await;
-    let health_th_playurl = health_key_to_char(redis, "0141301").await;
-    let health_cn_search = health_key_to_char(redis, "0211301").await;
-    let health_hk_search = health_key_to_char(redis, "0221301").await;
-    let health_tw_search = health_key_to_char(redis, "0231301").await;
-    let health_th_search = health_key_to_char(redis, "0241301").await;
-    let health_th_season = health_key_to_char(redis, "0441301").await;
+    // println!("[DEBUG] TEST PUSH, {:#?}", report_method);
+    let health_report_data = generate_health_report_data(redis_pool).await;
+    match report_method {
+        // telegram bot
+        ReportMethod::ReportConfigTgBot(config) => {
+            let url = format!(
+                "https://api.telegram.org/bot{}/sendMessage",
+                config.tg_bot_token
+            );
+            let content = format!(
+                "chat_id={}&text={}",
+                config.tg_chat_id,
+                health_report_data.generate_msg(report_method, health_data)
+            );
+            match async_postwebpage(
+                &url,
+                &content,
+                &config.tg_proxy_api_open,
+                &config.tg_proxy_url,
+                "BiliRoaming-Rust-Server",
+            ) // 虽然但是, 似乎也可以get, encode一下就可, 懒得改了
+            .await
+            {
+                Ok(_) => {
+                    return Ok(());
+                }
+                Err(_) => {
+                    return Err(());
+                }
+            }
+        }
+        // pushplus
+        ReportMethod::ReportConfigPushplus(config) => {
+            let url = format!(
+                "https://www.pushplus.plus/send/{}?topic={}&title={}&content={}&template=html",
+                config.pushplus_secret.clone(),
+                config.pushplus_group_id.clone(),
+                encode(&config.pushplus_push_title),
+                encode(&health_report_data.generate_msg(report_method, health_data))
+            );
+            // must encode params before getwebpage
+            match async_getwebpage(&url, &false, "", "BiliRoaming-Rust-Server", "").await {
+                Ok(_) => {
+                    return Ok(());
+                }
+                Err(_) => {
+                    return Err(());
+                }
+            }
+        }
+        // 自定义
+        ReportMethod::ReportConfigCustom(config) => {
+            match config.method {
+                super::types::Method::Get => {
+                    let url = config
+                        .build_url(
+                            &health_report_data.health_cn_playurl,
+                            &health_report_data.health_hk_playurl,
+                            &health_report_data.health_tw_playurl,
+                            &health_report_data.health_th_playurl,
+                            &health_report_data.health_cn_search,
+                            &health_report_data.health_hk_search,
+                            &health_report_data.health_tw_search,
+                            &health_report_data.health_th_search,
+                            &health_report_data.health_th_season,
+                            &health_data.area_name(),
+                            &health_data.data_type.to_string(),
+                            &health_data.health_type.to_color_char(),
+                        )
+                        .unwrap();
+                    match async_getwebpage(&url, &false, "", "BiliRoaming-Rust-Server", "").await {
+                        Ok(_) => {
+                            return Ok(());
+                        }
+                        Err(_) => {
+                            return Err(());
+                        }
+                    }
+                }
+                super::types::Method::Post => {
+                    let url = config
+                        .build_url(
+                            &health_report_data.health_cn_playurl,
+                            &health_report_data.health_hk_playurl,
+                            &health_report_data.health_tw_playurl,
+                            &health_report_data.health_th_playurl,
+                            &health_report_data.health_cn_search,
+                            &health_report_data.health_hk_search,
+                            &health_report_data.health_tw_search,
+                            &health_report_data.health_th_search,
+                            &health_report_data.health_th_season,
+                            &health_data.area_name(),
+                            &health_data.data_type.to_string(),
+                            &health_data.health_type.to_color_char(),
+                        )
+                        .unwrap();
+                    let content = config
+                        .build_content(
+                            &health_report_data.health_cn_playurl,
+                            &health_report_data.health_hk_playurl,
+                            &health_report_data.health_tw_playurl,
+                            &health_report_data.health_th_playurl,
+                            &health_report_data.health_cn_search,
+                            &health_report_data.health_hk_search,
+                            &health_report_data.health_tw_search,
+                            &health_report_data.health_th_search,
+                            &health_report_data.health_th_season,
+                            &health_data.area_name(),
+                            &health_data.data_type.to_string(),
+                            &health_data.health_type.to_color_char(),
+                        )
+                        .unwrap();
+                    // println!("[Debug] content:{}", content);
+                    match async_postwebpage(&url, &content, &false, "", "BiliRoaming-Rust-Server")
+                        .await
+                    {
+                        Ok(_) => {
+                            return Ok(());
+                        }
+                        Err(_) => {
+                            return Err(());
+                        }
+                    }
+                }
+            }
+        }
+        ReportMethod::ReportConfigNone => return Ok(()),
+    }
+}
 
-    match config.method {
-        super::types::Method::Get => {
-            let url = config
-                .build_url(
-                    &health_cn_playurl,
-                    &health_hk_playurl,
-                    &health_tw_playurl,
-                    &health_th_playurl,
-                    &health_cn_search,
-                    &health_hk_search,
-                    &health_tw_search,
-                    &health_th_search,
-                    &health_th_season,
-                    &health_data.area_name(),
-                    &health_data.data_type.to_string(),
-                    &health_data.health_type.to_color_char(),
-                )
-                .unwrap();
-            match getwebpage(
-                url,
-                false,
-                "".to_string(),
-                "BiliRoaming-Rust-Server".to_string(),
-                "".to_string(),
-            ) {
-                Ok(_) => {
-                    return Ok(());
-                }
-                Err(_) => {
-                    return Err(());
-                }
-            }
-        }
-        super::types::Method::Post => {
-            let url = config
-                .build_url(
-                    &health_cn_playurl,
-                    &health_hk_playurl,
-                    &health_tw_playurl,
-                    &health_th_playurl,
-                    &health_cn_search,
-                    &health_hk_search,
-                    &health_tw_search,
-                    &health_th_search,
-                    &health_th_season,
-                    &health_data.area_name(),
-                    &health_data.data_type.to_string(),
-                    &health_data.health_type.to_color_char(),
-                )
-                .unwrap();
-            let content = config
-                .build_content(
-                    &health_cn_playurl,
-                    &health_hk_playurl,
-                    &health_tw_playurl,
-                    &health_th_playurl,
-                    &health_cn_search,
-                    &health_hk_search,
-                    &health_tw_search,
-                    &health_th_search,
-                    &health_th_season,
-                    &health_data.area_name(),
-                    &health_data.data_type.to_string(),
-                    &health_data.health_type.to_color_char(),
-                )
-                .unwrap();
-            // println!("[Debug] content:{}", content);
-            match postwebpage(
-                url,
-                content,
-                false,
-                "".to_string(),
-                "BiliRoaming-Rust-Server".to_string(),
-            ) {
-                Ok(_) => {
-                    return Ok(());
-                }
-                Err(_) => {
-                    return Err(());
-                }
-            }
-        }
+async fn health_key_to_char(key: &str) -> String {
+    match key {
+        "0" => "🟢".to_string(),
+        "1" => "🟡".to_string(),
+        "2" => "🟠".to_string(),
+        "3" => "🟠".to_string(),
+        "4" => "🔴".to_string(),
+        _ => "🔴".to_string(),
+    }
+}
+
+async fn generate_health_report_data(redis_pool: &Pool) -> ReportHealthData {
+    let health_cn_playurl = redis_get(redis_pool, "0111301")
+        .await
+        .unwrap_or("4".to_string());
+    let health_hk_playurl = redis_get(redis_pool, "0121301")
+        .await
+        .unwrap_or("4".to_string());
+    let health_tw_playurl = redis_get(redis_pool, "0131301")
+        .await
+        .unwrap_or("4".to_string());
+    let health_th_playurl = redis_get(redis_pool, "0141301")
+        .await
+        .unwrap_or("4".to_string());
+    let health_cn_search = redis_get(redis_pool, "0211301")
+        .await
+        .unwrap_or("4".to_string());
+    let health_hk_search = redis_get(redis_pool, "0221301")
+        .await
+        .unwrap_or("4".to_string());
+    let health_tw_search = redis_get(redis_pool, "0231301")
+        .await
+        .unwrap_or("4".to_string());
+    let health_th_search = redis_get(redis_pool, "0241301")
+        .await
+        .unwrap_or("4".to_string());
+    let health_th_season = redis_get(redis_pool, "0441301")
+        .await
+        .unwrap_or("4".to_string());
+    ReportHealthData {
+        health_cn_playurl: health_key_to_char(&health_cn_playurl).await,
+        health_hk_playurl: health_key_to_char(&health_hk_playurl).await,
+        health_tw_playurl: health_key_to_char(&health_tw_playurl).await,
+        health_th_playurl: health_key_to_char(&health_th_playurl).await,
+        health_cn_search: health_key_to_char(&health_cn_search).await,
+        health_hk_search: health_key_to_char(&health_hk_search).await,
+        health_tw_search: health_key_to_char(&health_tw_search).await,
+        health_th_search: health_key_to_char(&health_th_search).await,
+        health_th_season: health_key_to_char(&health_th_season).await,
     }
 }

--- a/src/mods/tools.rs
+++ b/src/mods/tools.rs
@@ -244,22 +244,6 @@ pub fn update_server(is_auto_close: bool) {
     });
 }
 
-pub async fn health_key_to_char(pool: &Pool, key: &str) -> String {
-    match redis_get(pool, key).await {
-        Some(value) => match &value[..] {
-            "0" => return "🟢".to_string(),
-            "1" => return "🟡".to_string(),
-            "2" => return "🟠".to_string(),
-            "3" => return "🟠".to_string(),
-            "4" => return "🔴".to_string(),
-            _ => return "🔴".to_string(),
-        },
-        None => {
-            return "🔴".to_string();
-        }
-    }
-}
-
 #[inline]
 pub async fn get_ep_area(pool: &Pool, ep: &str, area: &u8) -> Result<GetEpAreaType, ()> {
     let key = format!("e{ep}1401");


### PR DESCRIPTION
custom push中, Get类型如果不encode params会推送失败

同时添加pushplus, 固化了tg推送和pushplus推送, (~~后续我想写主动式健康检查, 推送详细报告, 免得又得ssh到服务器看日志~~), 原来的的修改为自定义推送的形式(custom)

但是report_config这部分不兼容老版本的config了(虽然不影响运行, 推送不生效而已)

这个commit无意间已经把beta分支里的fix bug这个commit fix的内容给fix了(除了版本号)