### PR TITLE
fix: unknown appkey causes -404 when getting user info

### DIFF
--- a/src/mods/background_tasks.rs
+++ b/src/mods/background_tasks.rs
@@ -158,7 +158,7 @@ pub async fn background_task_run(
                             Some(health_data) => {
                                 let err_num = health_data.parse::<u16>().unwrap_or(max_num_of_err);
                                 bili_runtime.redis_set(&redis_key, "0", 0).await;
-                                if err_num != 0 {
+                                if err_num >= max_num_of_err {
                                     send_report(&redis_pool, &report_config, &value)
                                         .await
                                         .unwrap_or_default();
@@ -235,7 +235,8 @@ pub async fn background_task_run(
                         Ok(())
                     }
                     Err(value) => Err(format!(
-                        "[BACKGROUND TASK] | Playurl cache refresh failed, ErrMsg: {}", value.to_string()
+                        "[BACKGROUND TASK] | Playurl cache refresh failed, ErrMsg: {}",
+                        value.to_string()
                     )),
                 }
             }

--- a/src/mods/types.rs
+++ b/src/mods/types.rs
@@ -1600,8 +1600,8 @@ impl<'bili_playurl_params: 'playurl_params_impl, 'playurl_params_impl>
             "27eb53fc9058f8c3" => "c2ed53a74eeefe3cf99fbd01d8c9c375", // ios
             "57263273bc6b67f6" => "a0488e488d1567960d3a765e8d129f90", // Android
             "7d336ec01856996b" => "a1ce6983bc89e20a36c37f40c4f1a0dd", // AndroidB
-            "85eb6835b0a1034e" => "2ad42749773c441109bdc0191257a664", // unknown
-            "84956560bc028eb7" => "94aba54af9065f71de72f5508f1cd42e", // unknown
+            "85eb6835b0a1034e" => "2ad42749773c441109bdc0191257a664", // unknown // 不能用于获取UserInfo, 会404
+            "84956560bc028eb7" => "94aba54af9065f71de72f5508f1cd42e", // unknown // 不能用于获取UserInfo, 会404
             "8e16697a1b4f8121" => "f5dd03b752426f2e623d7badb28d190a", // AndroidI
             "aae92bc66f3edfab" => "af125a0d5279fd576c1b4418a3e8276d", // PC	投稿工具
             "ae57252b0c09105d" => "c75875c596a69eb55bd119e74b07cfe3", // AndroidI
@@ -1612,6 +1612,7 @@ impl<'bili_playurl_params: 'playurl_params_impl, 'playurl_params_impl>
             //_ => Ok("560c52ccd288fed045859ed18bffd973"),
             _ => return Err(()),
         };
+        // if self.appsec =
         Ok(())
     }
     pub fn init_params(&mut self, area: Area) {


### PR DESCRIPTION
发现有两个unknown的appkey不能用于获取用户信息, 这两个appkey估计是已经被废弃了. 不过还能拿来获取playurl.
替换成android的appkey, appsec也能用, 不过看了看日志, 鲜少用这两个appkey的, 用了的, UA出奇的一致(`Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.198 Safari/537.36`), 甚至还有没有UA的, 感觉像旧版油猴插件, 或者某种第三方客户端... 
改成通过background_task去存个缓存, `update_cached_user_info_background`默认是用android的appkey, appsec的. 
