### PR TITLE
fix: get_user_info error -663

### DIFF
--- a/src/mods/tools.rs
+++ b/src/mods/tools.rs
@@ -28,7 +28,7 @@ pub fn check_vip_status_from_playurl(
                         quality_need_vip.push(item["quality"].as_u64().unwrap_or(0));
                     }
                 }
-                
+
                 if quality_need_vip.len() != 0 {
                     for video in data["dash"]["video"].as_array().unwrap() {
                         if quality_need_vip.contains(&video["id"].as_u64().unwrap_or(0)) {
@@ -38,7 +38,8 @@ pub fn check_vip_status_from_playurl(
                     return Ok(false);
                 }
 
-                match data["vip_status"].as_i64().unwrap_or(2) { // 这种方法会让 试看 的情况出现问题,所以不作为首选方法
+                match data["vip_status"].as_i64().unwrap_or(2) {
+                    // 这种方法会让 试看 的情况出现问题,所以不作为首选方法
                     1 => {
                         return Ok(true);
                     }
@@ -162,11 +163,12 @@ pub async fn remove_viponly_clarity<'a>(
                 let mut support_format_allowed = serde_json::Value::Null; //获取最高画质那档的信息
                 let mut support_format_allowed_found = false;
                 // 移除support_formats里的need_vip内容
-                let support_formats = if let Some(value) = data_json["support_formats"].as_array_mut(){
-                    value
-                }else{
-                    return None;
-                };
+                let support_formats =
+                    if let Some(value) = data_json["support_formats"].as_array_mut() {
+                        value
+                    } else {
+                        return None;
+                    };
                 support_formats.retain(|support_format| {
                     if support_format.as_object().unwrap().contains_key("need_vip")
                         && support_format["need_vip"].as_bool().unwrap_or(true)
@@ -269,6 +271,24 @@ pub async fn remove_viponly_clarity<'a>(
         }
     };
     Some(new_return_data)
+}
+
+#[inline]
+/// - 部分API似乎开始验证mobi_app这个参数, 否则可能报告 `{"code":-663,"message":"鉴权失败，请联系账号组","ttl":1}`.
+/// - 返回(`appkey`, `appsec`, `mobi_app`).
+pub fn get_mobi_app(appkey: &str) -> (&'static str, &'static str, &'static str) {
+    match appkey {
+        "1d8b6e7d45233436"=> ("1d8b6e7d45233436", "560c52ccd288fed045859ed18bffd973", "android"),
+        "07da50c9a0bf829f"=> ("07da50c9a0bf829f", "25bdede4e1581c836cab73a48790ca6e", "android_b"),
+        "dfca71928277209b"=> ("dfca71928277209b", "b5475a8825547a4fc26c7d518eaaa02e", "android_hd"), // 不确定是不是这个...
+        "bb3101000e232e27"=> ("bb3101000e232e27", "36efcfed79309338ced0380abd824ac1", "android_i"),
+        "178cf125136ca8ea"=> ("178cf125136ca8ea", "34381a26236dd1171185c0beb042e1c6", "android_b"),
+        // "27eb53fc9058f8c3"=> ("27eb53fc9058f8c3", "c2ed53a74eeefe3cf99fbd01d8c9c375", "ios"), // 没有iOS用户吧...
+        "57263273bc6b67f6"=> ("57263273bc6b67f6", "a0488e488d1567960d3a765e8d129f90", "android"),
+        "7d336ec01856996b"=> ("7d336ec01856996b", "a1ce6983bc89e20a36c37f40c4f1a0dd", "android_b"),
+        "ae57252b0c09105d"=> ("ae57252b0c09105d", "c75875c596a69eb55bd119e74b07cfe3", "android_i"),
+        _ => ("1d8b6e7d45233436", "560c52ccd288fed045859ed18bffd973", "android") // 默认值
+    }
 }
 
 pub fn update_server<T: std::fmt::Display>(is_auto_close: bool) {


### PR DESCRIPTION
部分API似乎开始验证mobi_app这个参数, 否则可能报告 `{"code":-663,"message":"鉴权失败，请联系账号组","ttl":1}`. 预备一下. 
同时在请求user_info遇到这个错误应该是限制请求频率. 大概每秒累计最多5次. 
持续观察后续情况, 先不merge.

错误日志: 
```
12月 06 12:20:07 debian biliroaming_rust_server[1084672]: [2022-12-06 12:20:07][DEBUG] [GET USER_INFO][U] AK a9336424a90c3a8e50b062774608**** | Upstream Reply: {"code":-663,"message":"鉴权失败，请联系账号组","ttl":1}
12月 06 12:20:07 debian biliroaming_rust_server[1084672]: [2022-12-06 12:20:07][ERROR] [GET USER_INFO][U] AK a9336424a90c3a8e50b062774608**** -> Get UserInfo failed. REQ Params -> APPKEY 1d8b6e7d45233436 | TS 1670300407 | APPSEC 560c52ccd288fed045859ed18bffd973 | SIGN ecf3eaeb9b2670a81c4c6b30bb13d882. Upstream Reply -> {"code":-663,"message":"鉴权失败，请联系账号组","ttl":1}
12月 06 14:40:12 debian biliroaming_rust_server[1084672]: [2022-12-06 14:40:12][DEBUG] [GET USER_INFO][U] AK f7f3ca15e42c9a43b79245af75c5**** | Upstream Reply: {"code":-663,"message":"鉴权失败，请联系账号组","ttl":1}
12月 06 14:40:12 debian biliroaming_rust_server[1084672]: [2022-12-06 14:40:12][ERROR] [GET USER_INFO][U] AK f7f3ca15e42c9a43b79245af75c5**** -> Get UserInfo failed. REQ Params -> APPKEY 1d8b6e7d45233436 | TS 1670308807 | APPSEC 560c52ccd288fed045859ed18bffd973 | SIGN 50b7c0b770ede55dc209493e0eb719dd. Upstream Reply -> {"code":-663,"message":"鉴权失败，请联系账号组","ttl":1}
12月 06 14:40:14 debian biliroaming_rust_server[1084672]: [2022-12-06 14:40:14][DEBUG] [GET USER_INFO][U] AK f7f3ca15e42c9a43b79245af75c5**** | Upstream Reply: {"code":-663,"message":"鉴权失败，请联系账号组","ttl":1}
12月 06 14:40:14 debian biliroaming_rust_server[1084672]: [2022-12-06 14:40:14][ERROR] [GET USER_INFO][U] AK f7f3ca15e42c9a43b79245af75c5**** -> Get UserInfo failed. REQ Params -> APPKEY 1d8b6e7d45233436 | TS 1670308814 | APPSEC 560c52ccd288fed045859ed18bffd973 | SIGN 5304595d7e068df543e88c95f060a085. Upstream Reply -> {"code":-663,"message":"鉴权失败，请联系账号组","ttl":1}
```

